### PR TITLE
support non-external delta ref before base

### DIFF
--- a/plumbing/format/packfile/parser.go
+++ b/plumbing/format/packfile/parser.go
@@ -234,6 +234,15 @@ func (p *Parser) indexObjects() error {
 				return err
 			}
 
+			// move children of placeholder parent into actual parent in case this was
+			// a non-external delta reference
+			if placeholder, ok := p.oiByHash[sha1]; ok {
+				ota.Children = placeholder.Children
+				for _, c := range ota.Children {
+					c.Parent = ota
+				}
+			}
+
 			ota.SHA1 = sha1
 			p.oiByHash[ota.SHA1] = ota
 		}


### PR DESCRIPTION
Copy of https://github.com/go-git/go-git/pull/485

Tested our specific repo case w/ https://github.com/go-git/go-git-fixtures/commit/ce2aa44b756e403a7fce249b34a893cf6607c9c0
```
func (s *ParserSuite) TestDOTest(c *C) {
	extRefsThinPack := fixtures.ByTag("do-test").One()

	scanner := packfile.NewScanner(extRefsThinPack.Packfile())

	obs := new(testObserver)
	parser, err := packfile.NewParser(scanner, obs)
	c.Assert(err, IsNil)

	_, err = parser.Parse()
	c.Assert(err, IsNil)
}
```