### PR TITLE
git: submodule: handle submodule ssh url. Fixes #488

### DIFF
--- a/submodule.go
+++ b/submodule.go
@@ -20,7 +20,7 @@ var (
 	ErrSubmoduleNotInitialized     = errors.New("submodule not initialized")
 
 	// gitSubmoduleSSHRegex matches a submodule repository that connects over ssh
-	gitSubmoduleSSHRegex = regexp.MustCompile(`^\"?(ssh://)?[A-Za-z_]+@[a-zA-Z0-9._-]+:[a-zA-Z0-9./._-]+\/.*\"?$`)
+	gitSubmoduleSSHRegex = regexp.MustCompile(`^\"?(?:ssh|git@[-\w.]+):(\/\/)?(.*?)(\.git)\"?$`)
 )
 
 // Submodule a submodule allows you to keep another Git repository in a


### PR DESCRIPTION
Git submodule urls can be referenced by ssh. When using ssh to connect,
url.Parse rejects an ssh url without the scheme (ssh://...).